### PR TITLE
Feat/spt 55/send access token and username to frontend

### DIFF
--- a/backend/routes/AuthRoutes.js
+++ b/backend/routes/AuthRoutes.js
@@ -13,11 +13,10 @@ router.get('/github/callback', async (req, res) => {
     try {
         const { code } = req.query;
         const tokenData = await authService.exchangeCodeForToken(code);
-        const token = encodeURIComponent(tokenData.accessToken);
-        const username = 'a';
+        const token = encodeURIComponent(tokenData.access_token);
+        const username = encodeURIComponent(tokenData.username);
         const url = `https://spiderman-trivia-inc.github.io/Spiderman-Trivia-Inc/frontend/callback#token=${token}&username=${username}`;
         res.redirect(url);
-        sendResponse(res, 200, tokenData);
     } catch (error) {
         sendError(res, error);
     }

--- a/backend/routes/AuthRoutes.js
+++ b/backend/routes/AuthRoutes.js
@@ -13,11 +13,10 @@ router.get('/github/callback', async (req, res) => {
     try {
         const { code } = req.query;
         const tokenData = await authService.exchangeCodeForToken(code);
-        /** I was thinking of sending the access token by having a callback on the frontend
-         * it should take that token and save it to localStorage
-        const url = `http://spiderman-frontend.com/login-success?token=${encodeURIComponent(tokenData.accessToken)}`;
+        const token = encodeURIComponent(tokenData.accessToken);
+        const username = 'a';
+        const url = `https://spiderman-trivia-inc.github.io/Spiderman-Trivia-Inc/frontend/callback#token=${token}&username=${username}`;
         res.redirect(url);
-        */
         sendResponse(res, 200, tokenData);
     } catch (error) {
         sendError(res, error);

--- a/backend/services/AuthService.js
+++ b/backend/services/AuthService.js
@@ -39,7 +39,7 @@ class AuthService {
         const githubUserData = await this.getGithubUserInfo(accessToken);
         const user = await UserService.findOrCreateUser(githubUserData);
         const jwtToken = this.generateJWT(user);
-        return { access_token: jwtToken};
+        return { access_token: jwtToken, username:user.username};
     }
 
     async getGithubUserInfo(accessToken) {


### PR DESCRIPTION
now that the frontend has a callback to receive a token and username, we use the api to send those two to it after authentication